### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contoso-traders-provisioning-deployment.yml
+++ b/.github/workflows/contoso-traders-provisioning-deployment.yml
@@ -1,5 +1,8 @@
 name: contoso-traders-app-deployment
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-150/github-cloudlabsuser-150-aiw-devops-with-github-lab-files/security/code-scanning/4](https://github.com/github-cloudlabsuser-150/github-cloudlabsuser-150-aiw-devops-with-github-lab-files/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the minimum required permissions for the `GITHUB_TOKEN`. Based on the actions used in the workflow, such as `actions/checkout`, `azure/login`, and `azure/CLI`, the workflow primarily interacts with repository contents and Azure resources. Therefore, we will set `contents: read` as the default permission and add any additional permissions required for specific jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
